### PR TITLE
Fixes "Too many open files"

### DIFF
--- a/src/LDX/TimeCommander/Main.php
+++ b/src/LDX/TimeCommander/Main.php
@@ -9,11 +9,8 @@ use pocketmine\plugin\PluginBase;
 use pocketmine\Server;
 class Main extends PluginBase {
   public function onEnable() {
-    if(!file_exists($this->getDataFolder() . "config.yml")) {
-      @mkdir($this->getDataFolder());
-      file_put_contents($this->getDataFolder() . "config.yml",$this->getResource("config.yml"));
-    }
-    $c = yaml_parse(file_get_contents($this->getDataFolder() . "config.yml"));
+    $this->saveDefaultConfig();
+    $c = $this->getConfig()->getAll();
     foreach ($c["Commands"] as $i) {
       $this->getServer()->getScheduler()->scheduleRepeatingTask(new TimeCommand($this,$i["Command"]),$i["Time"] * 1200);
     }


### PR DESCRIPTION
This fixes issues with not closing resources given by PocketMine, causing a crash at a later stage.
Users usually blame PocketMine for this, but it's entirely a plugin's fault.

This code was found via GitHub search, please review your code for usage of:
- `Plugin->getResource()` without `fclose()` calls later
- Not needed `Plugin->getResource()` calls
- `fopen()` calls without `fclose()`
- `popen()` calls without `pclose()`
